### PR TITLE
Fix github actions warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,17 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        run: |
+          RELEASE_TAG="${{ github.ref_name }}"
+          RELEASE_NAME="Release $RELEASE_TAG"
+          gh release create "$RELEASE_TAG" --title "$RELEASE_NAME" --notes ""
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build:
     name: Build
@@ -35,18 +36,16 @@ jobs:
       libname: NA2202_2203_2204
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
       - name: Archive
         run: |
           mkdir -p ${{ env.libname }}
-          mv  src/ examples/ library.properties keywords.txt LICENSE ${{ env.libname }}
-          7z a ${{ env.libname }}_${{ github.ref_name }}.zip ${{ env.libname }}
-      - name: Upload
-        uses: actions/upload-release-asset@v1
+          mv src/ examples/ library.properties keywords.txt LICENSE ${{ env.libname }}
+          zip -r ${{ env.libname }}_${{ github.ref_name }}.zip ${{ env.libname }}
+
+      - name: Upload Release Asset
+        run: |
+          gh release upload "${{ github.ref_name }}" "${{ env.libname }}_${{ github.ref_name }}.zip"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ env.libname }}_${{ github.ref_name }}.zip
-          asset_name: ${{ env.libname }}_${{ github.ref_name }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The official actions `actions/create-release` and `actions/upload-release-asset` are outdated and produce warnings.  
Replace them with `gh` CLI commands.